### PR TITLE
Require Craft 3 RC1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
     "issues": "https://github.com/enupal/slider/issues",
     "docs": "https://enupal.com/en/craft-plugins/enupal-slider/docs/getting-started/overview"
   },
+  "require": {
+    "craftcms/cms": "^3.0.0-RC1"
+  },
   "extra": {
     "name": "Enupal Slider",
     "handle": "enupal-slider",


### PR DESCRIPTION
The Plugin Store is eventually going to require that plugins define their Craft CMS compatibility, via the `require` property in composer.json.